### PR TITLE
Manifold - add api fetching logic

### DIFF
--- a/src/jobs/index.ts
+++ b/src/jobs/index.ts
@@ -6,6 +6,7 @@ import "./x2y2-sync";
 import "./element-sync";
 import "./coinbase-sync";
 import "./rarible-sync";
+import "./manifold-sync";
 
 import * as looksRareSyncRealtime from "./looksrare-sync/realtime-queue";
 import * as relayOrders from "./relay-orders";
@@ -30,6 +31,8 @@ import * as elementSyncOffersBackfill from "./element-sync/queues/backfill-queue
 import * as coinbaseSyncListingsRealtime from "./coinbase-sync/realtime-queue";
 import * as coinbaseSyncListingsBackfill from "./coinbase-sync/backfill-queue";
 
+import * as manifoldSyncListingsRealtime from "./manifold-sync/realtime-queue";
+
 export const allQueues = [
   looksRareSyncRealtime.realtimeQueue,
   relayOrders.queue,
@@ -50,4 +53,5 @@ export const allQueues = [
   coinbaseSyncListingsBackfill.backfillQueue,
   raribleSyncRealtime.realtimeQueue,
   raribleSyncBackfill.backfillQueue,
+  manifoldSyncListingsRealtime.realtimeQueue,
 ];

--- a/src/jobs/manifold-sync/index.ts
+++ b/src/jobs/manifold-sync/index.ts
@@ -9,18 +9,18 @@ import * as manifoldSyncRealtime from "./realtime-queue";
 
 if (config.doRealtimeWork) {
   cron.schedule("* * * * *", async () => {
-    const cacheKey = "manifold-realtime-timestamp";
-    await redis.set(cacheKey, 0);
     if (_.indexOf([1, 5], config.chainId) !== -1) {
       const lockAcquired = await acquireLock("manifold-sync-lock", 60 * 5);
       if (lockAcquired) {
-        const cacheKey = "manifold-realtime-timestamp";
-        const timestamp = await redis.get(cacheKey);
+        const cacheIdKey = "manifold-realtime-id";
+        const cachePageKey = "manifold-realtime-page";
+        const id = Number((await redis.get(cacheIdKey)) || 0);
+        const page = Number((await redis.get(cachePageKey)) || 1);
 
         await manifoldSyncRealtime.addToRealtimeQueue();
         logger.info(
           manifoldSyncRealtime.realtimeQueue.name,
-          `Start Manifold sync from timestamp=(${timestamp})`
+          `Start Manifold sync from id=(${id}), page=(${page})`
         );
       }
     }

--- a/src/jobs/manifold-sync/index.ts
+++ b/src/jobs/manifold-sync/index.ts
@@ -1,0 +1,28 @@
+import cron from "node-cron";
+import _ from "lodash";
+
+import { config } from "../../config";
+import { acquireLock, redis } from "../../common/redis";
+import { logger } from "../../common/logger";
+
+import * as manifoldSyncRealtime from "./realtime-queue";
+
+if (config.doRealtimeWork) {
+  cron.schedule("* * * * *", async () => {
+    const cacheKey = "manifold-realtime-timestamp";
+    await redis.set(cacheKey, 0);
+    if (_.indexOf([1, 5], config.chainId) !== -1) {
+      const lockAcquired = await acquireLock("manifold-sync-lock", 60 * 5);
+      if (lockAcquired) {
+        const cacheKey = "manifold-realtime-timestamp";
+        const timestamp = await redis.get(cacheKey);
+
+        await manifoldSyncRealtime.addToRealtimeQueue();
+        logger.info(
+          manifoldSyncRealtime.realtimeQueue.name,
+          `Start Manifold sync from timestamp=(${timestamp})`
+        );
+      }
+    }
+  });
+}

--- a/src/jobs/manifold-sync/realtime-queue.ts
+++ b/src/jobs/manifold-sync/realtime-queue.ts
@@ -1,0 +1,70 @@
+import _ from "lodash";
+
+import { Job, Queue, QueueScheduler, Worker } from "bullmq";
+import { redis, extendLock, releaseLock } from "../../common/redis";
+import { config } from "../../config";
+import { fetchOrders } from "./utils";
+import { logger } from "../../common/logger";
+
+const REALTIME_QUEUE_NAME = "realtime-manifold-sync";
+
+export const realtimeQueue = new Queue(REALTIME_QUEUE_NAME, {
+  connection: redis.duplicate(),
+  defaultJobOptions: {
+    attempts: 1,
+    backoff: {
+      type: "fixed",
+      delay: 3,
+    },
+    timeout: 60000,
+    removeOnComplete: 10000,
+    removeOnFail: 100,
+  },
+});
+new QueueScheduler(REALTIME_QUEUE_NAME, { connection: redis.duplicate() });
+
+if (config.doRealtimeWork) {
+  const realtimeWorker = new Worker(
+    REALTIME_QUEUE_NAME,
+    async (job: Job) => {
+      try {
+        const cacheKey = "manifold-realtime-timestamp";
+        let timestamp = Number((await redis.get(cacheKey)) || 0);
+
+        const newTimestamp = await fetchOrders(timestamp);
+
+        if (timestamp === newTimestamp) {
+          logger.info(
+            REALTIME_QUEUE_NAME,
+            `manifold realtime timestamp didn't change timestamp=${timestamp}, newTimestamp=${newTimestamp}`
+          );
+        } else {
+          await redis.set(cacheKey, newTimestamp);
+        }
+      } catch (error) {
+        logger.error(
+          REALTIME_QUEUE_NAME,
+          `Manifold Sync failed attempts=${job.attemptsMade}, error=${error}`
+        );
+      }
+    },
+    { connection: redis.duplicate(), concurrency: 2 }
+  );
+
+  realtimeWorker.on("completed", async (job) => {
+    // Release the lock to allow the next sync
+    await releaseLock("manifold-sync-lock", false);
+
+    if (job.attemptsMade > 0) {
+      logger.info(REALTIME_QUEUE_NAME, `Sync recover attempts=${job.attemptsMade}`);
+    }
+  });
+
+  realtimeWorker.on("error", (error) => {
+    logger.error(REALTIME_QUEUE_NAME, `Worker errored: ${error}`);
+  });
+}
+
+export const addToRealtimeQueue = async (delayMs: number = 0, cursor: string = "") => {
+  await realtimeQueue.add(REALTIME_QUEUE_NAME, { cursor }, { delay: delayMs });
+};

--- a/src/jobs/manifold-sync/utils.ts
+++ b/src/jobs/manifold-sync/utils.ts
@@ -1,0 +1,85 @@
+import * as Sdk from "@reservoir0x/sdk";
+import axios from "axios";
+import pLimit from "p-limit";
+import _ from "lodash";
+
+import { db, pgp } from "../../common/db";
+import { addToRelayOrdersQueue } from "../relay-orders";
+import { logger } from "../../common/logger";
+import { Manifold, ManifoldOrder } from "../../utils/manifold";
+
+export const fetchOrders = async (timestamp: number) => {
+  const manifold = new Manifold();
+
+  let newOrdersCount = 0;
+  let newTimestamp = timestamp;
+
+  try {
+    const url = manifold.buildFetchListingsURL();
+    const response = await axios.get(url, { timeout: 10000 });
+
+    const newOrders: ManifoldOrder[] = response.data.filter(
+      (order: ManifoldOrder) => order.createdAt > timestamp
+    );
+
+    const parsedOrders: Sdk.Manifold.Order[] = [];
+
+    const values: any[] = [];
+
+    const handleOrder = async (order: ManifoldOrder) => {
+      const orderTarget = order.token.address_;
+      const parsed = await manifold.parseManifoldOrder(order);
+
+      if (parsed) {
+        parsedOrders.push(parsed);
+
+        // Update timestamp if newer
+        const orderTimestamp = order.createdAt;
+        if (orderTimestamp > timestamp) {
+          newTimestamp = orderTimestamp;
+        }
+      }
+
+      values.push({
+        hash: order.id,
+        target: orderTarget.toLowerCase(),
+        maker: order.seller.toLowerCase(),
+        created_at: new Date(order.details.startTime),
+        data: order,
+        source: "manifold",
+      });
+    };
+
+    const plimit = pLimit(20);
+    await Promise.all(newOrders.map((order) => plimit(() => handleOrder(order))));
+
+    if (values.length) {
+      const columns = new pgp.helpers.ColumnSet(
+        ["hash", "target", "maker", "created_at", "data", "source"],
+        { table: "orders_v23" }
+      );
+
+      const result = await db.manyOrNone(
+        pgp.helpers.insert(values, columns) + " ON CONFLICT DO NOTHING RETURNING 1"
+      );
+
+      newOrdersCount = _.size(result); // Number of newly inserted rows
+    }
+
+    if (parsedOrders.length) {
+      await addToRelayOrdersQueue(
+        parsedOrders.map((order) => ({
+          kind: "manifold",
+          data: order.params,
+        })),
+        true
+      );
+    }
+  } catch (error) {
+    throw error;
+  }
+
+  logger.info("fetch_orders_manifold", `FINAL - manifold - Got ${newOrdersCount} new orders`);
+
+  return newTimestamp;
+};

--- a/src/jobs/manifold-sync/utils.ts
+++ b/src/jobs/manifold-sync/utils.ts
@@ -14,9 +14,9 @@ export const fetchOrders = async (id: number, page: number) => {
   let newOrdersCount = 0;
   let newOrderId = id;
   let newPage = page;
-
+  let pageSize = 100;
   try {
-    const url = manifold.buildFetchListingsURL(page);
+    const url = manifold.buildFetchListingsURL(page, pageSize);
     const response = await axios.get(url, { timeout: 10000 });
 
     // type_ === 2 filters fixed price listings
@@ -25,7 +25,7 @@ export const fetchOrders = async (id: number, page: number) => {
     );
     const pageOrderCount = response.data.count;
     // Manifold api returns 20 orders. If we've received 20 orders, then it's time to start fetching the next page
-    if (pageOrderCount === 20) {
+    if (pageOrderCount === pageSize) {
       newPage += 1;
     }
     const parsedOrders: Sdk.Manifold.Order[] = [];

--- a/src/migrations/1668418818530_add-manifold.ts
+++ b/src/migrations/1668418818530_add-manifold.ts
@@ -1,0 +1,5 @@
+import { MigrationBuilder } from "node-pg-migrate";
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  pgm.addTypeValue("source_t", "manifold");
+}

--- a/src/utils/manifold.ts
+++ b/src/utils/manifold.ts
@@ -46,12 +46,12 @@ enum Spec {
 }
 
 export class Manifold {
-  public buildFetchListingsURL = (page: number) => {
+  public buildFetchListingsURL = (page: number, pageSize: number) => {
     switch (config.chainId) {
       case 1:
-        return `https://marketplace.api.manifoldxyz.dev/listing/0x3a3548e060be10c2614d0a4cb0c03cc9093fd799/activity?sortAscending=true&pageNumber=${page}`;
+        return `https://marketplace.api.manifoldxyz.dev/listing/0x3a3548e060be10c2614d0a4cb0c03cc9093fd799/activity?sortAscending=true&pageNumber=${page}&pageSize=${pageSize}`;
       case 5:
-        return `https://goerli.marketplace.api.manifoldxyz.dev/listing/0x554fa73be2f122374e148b35de3ed6c34602dbf6/activity?sortAscending=true&pageNumber=${page}`;
+        return `https://goerli.marketplace.api.manifoldxyz.dev/listing/0x554fa73be2f122374e148b35de3ed6c34602dbf6/activity?sortAscending=true&pageNumber=${page}&pageSize=${pageSize}`;
       default:
         throw Error(`Unknown chain id: ${config.chainId}`);
     }

--- a/src/utils/manifold.ts
+++ b/src/utils/manifold.ts
@@ -47,7 +47,6 @@ export type ManifoldOrder = {
     };
   };
   fees: {
-    //TODO: deliverFixed
     deliverFixed: null;
   };
   bid: {
@@ -81,10 +80,6 @@ export class Manifold {
     try {
       const order = new Sdk.Manifold.Order(config.chainId, manifoldOrder as any);
       return order;
-    } catch (err) {
-      // Skip any errors
-      //DEBUG PURPOSES ONLY:
-      console.log(err);
-    }
+    } catch {}
   }
 }

--- a/src/utils/manifold.ts
+++ b/src/utils/manifold.ts
@@ -1,0 +1,90 @@
+import * as Sdk from "@reservoir0x/sdk";
+
+import { config } from "../config";
+export type ManifoldOrder = {
+  id: string;
+  seller: string;
+  createdAt: number;
+  details: {
+    type_: number;
+    initialAmount: {
+      type: string;
+      hex: string;
+    };
+    totalAvailable: string;
+    totalPerSale: string;
+    extensionInterval: number;
+    erc20: string;
+    identityVerifier: string;
+    startTime: number;
+    endTime: number;
+  };
+  token: {
+    spec: string;
+    address_: string;
+    id: {
+      type: string;
+      hex: string;
+    };
+    lazy: boolean;
+    metadata: {
+      name: string;
+      image: string;
+      image_url: string;
+      attributes: {
+        value: string;
+        trait_type: string;
+      }[];
+      created_by: string;
+      description: string;
+      image_details: {
+        bytes: number;
+        width: number;
+        format: string;
+        height: number;
+        sha256: string;
+      };
+    };
+  };
+  fees: {
+    //TODO: deliverFixed
+    deliverFixed: null;
+  };
+  bid: {
+    amount: {
+      type: string;
+      hex: string;
+    };
+    timestamp: string;
+    bidder: string;
+  };
+  address: string;
+  version: string;
+};
+export class Manifold {
+  public buildFetchListingsURL = () => {
+    // type=2 is fixed price listings
+    // order=1 is sort by created at
+    switch (config.chainId) {
+      case 1:
+        return "https://marketplace.api.manifoldxyz.dev/listing/0x3a3548e060be10c2614d0a4cb0c03cc9093fd799/active?type=2&order=1";
+      case 5:
+        return "https://goerli.marketplace.api.manifoldxyz.dev/listing/0x554fa73be2f122374e148b35de3ed6c34602dbf6/active?type=2&order=1";
+      default:
+        throw Error(`Unknown chain id: ${config.chainId}`);
+    }
+  };
+
+  public async parseManifoldOrder(
+    manifoldOrder: ManifoldOrder
+  ): Promise<Sdk.Manifold.Order | undefined> {
+    try {
+      const order = new Sdk.Manifold.Order(config.chainId, manifoldOrder as any);
+      return order;
+    } catch (err) {
+      // Skip any errors
+      //DEBUG PURPOSES ONLY:
+      console.log(err);
+    }
+  }
+}

--- a/src/utils/rarible.ts
+++ b/src/utils/rarible.ts
@@ -103,10 +103,6 @@ export class Rarible {
     try {
       const order = new Sdk.Rarible.Order(config.chainId, raribleOrder as any);
       return order;
-    } catch (err) {
-      // Skip any errors
-      //DEBUG PURPOSES ONLY:
-      console.log(err);
-    }
+    } catch {}
   }
 }


### PR DESCRIPTION
The relayer fetching logic relies on order created at timestamps so that we don't process the same order twice. Having two orders with the same timestamp is very unlikely since the timestamps are in miliseconds